### PR TITLE
chore: inserting two images

### DIFF
--- a/views/Examinador/Exame.js
+++ b/views/Examinador/Exame.js
@@ -7,135 +7,182 @@ import { useIsFocused } from '@react-navigation/native';
 import styles from '../styles.js';
 import { userGlobal } from '../../global.js';
 import { db, storage } from '../../src/config/firebase.js';
-import { collection, getDocs, updateDoc, doc,  query, where} from 'firebase/firestore';
-import { uploadBytes, ref } from "firebase/storage";
-import { Buffer } from "buffer";
+import { collection, getDocs, updateDoc, doc, query, where } from 'firebase/firestore';
+import { uploadBytes, ref } from 'firebase/storage';
+import { Buffer } from 'buffer';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import loginStyle from '../Login/LoginStyle.js';
 
-
 class ExamInfo {
-    constructor(image, description) {
-        this.image = image;
-        this.description = description;
-    }
+  constructor(images, description) {
+    this.images = images;
+    this.description = description;
+  }
 }
 
-async function uploadImage(image, id) {
+async function uploadImage(image, id, eye) {
+  try {
     const { uri } = image;
-    const filename = 'imagens_exames/' + id + '.jpg';
+    const filename = `imagens_exames/${id}_Imagem_${eye}.jpg`;
 
-    // caso seja exportado para iOS, usar essa linha
-    // const uploadUri = Platform.OS === 'ios' ? uri.replace('file://', '') : uri;
-
-    const imageBase64 = uri.replace('data:image/jpeg;base64,', '');
-
-    const imageBytes = Buffer.from(imageBase64, "base64");
+    const response = await fetch(uri);
+    const imageBytes = await response.arrayBuffer();
 
     const imageRef = ref(storage, filename);
-    const result = await uploadBytes(imageRef, imageBytes);
+    
+    // Adicionando o tipo MIME ao salvar os bytes
+    const metadata = {
+      contentType: 'image/jpeg',
+    };
+
+    await uploadBytes(imageRef, imageBytes, metadata);
 
     return filename;
-}
-
-async function addExamInfo(patient, examInfo) {
-    let patientData = patient['dados'];
-    
-    // cria referência do documento do paciente no banco de dados
-    const patientRef = doc(db, 'exames', patient['id']);
-
-    // envia imagem para o Firebase Storage
-    const imageUrl = await uploadImage(examInfo.image, patient['id']);
-    patientData['image'] = imageUrl;
-    patientData['description'] = examInfo.description;
-
-    // atualiza somente os campos image e description a partir de um JSON
-    await updateDoc(patientRef, {
-        'image': imageUrl,
-        'description': examInfo.description,
-        'coletado': true,
-    });
-    return;
+  } catch (error) {
+    console.error('Erro ao fazer o upload da imagem:', error);
+    throw error;
+  }
 }
 
 export default function Exame({ route, navigation }) {
+  const { patient } = route.params;
+  const [description, setDescription] = useState('');
+  const [imageRight, setImageRight] = useState(null);
+  const [imageLeft, setImageLeft] = useState(null);
 
-    const { patient } = route.params;
+  const addInfo = async (patient, examInfo) => {
+    try {
+      let patientData = patient['dados'];
+      const patientRef = doc(db, 'exames', patient['id']);
+      
+      const imageUrls = await Promise.all(examInfo.images.map(async (image, index) => {
+        const imageUrl = await uploadImage(image.image, patient['id'], `${examInfo.images.length === 1 ? '' : index + 1}_Imagem_${image.eye}`);
+        return imageUrl;
+      }));
 
-    const getUserNavigate = async () => {
-        let users = new Array();
-        let userRef = collection(db, "usuario");
-        let acceptedQuery = query(userRef, where("email", "==", userGlobal.email));
-        let userSnapshot = await getDocs(acceptedQuery);
-        userSnapshot.forEach(u => {
-        users.push({'dados': u.data()});
-        });
-        
-        navigation.navigate('Examinador_Home', {
-          users: users
-      })
+      patientData['images'] = imageUrls;
+
+      await updateDoc(patientRef, {
+        'images': imageUrls,
+        'description': examInfo.description,
+        'coletado': true,
+      });
+    } catch (error) {
+      console.error('Erro ao adicionar informações do exame:', error);
+      throw error;
     }
+  };
 
-    const pickImage = async () => {
+  const uploadExam = async (patient, examInfo) => {
+    try {
+      await addInfo(patient, new ExamInfo([imageRight, imageLeft], description));
+      simpleAlert();
+      getUserNavigate();
+    } catch (error) {
+      console.error('Erro ao fazer o upload do exame:', error);
+    }
+  };
+
+  const pickImage = async (eye) => {
+    try {
       let result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.All,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 1,
       });
-        setImage(result);
-        return result;
-    };
-    const [description, setDescription] = useState('');
-    const [image, setImage] = useState(null);
 
-    const addInfo = async (patient, examInfo) => {
-        console.log(image)
-        await addExamInfo(patient, examInfo);
-    };
+      if (!result.cancelled) {
+        const image = { image: result, eye };
+        eye === 'direito' ? setImageRight(image) : setImageLeft(image);
+      }
 
-    const simpleAlert = () => {
-        alert("Imagem e descrição enviados com sucesso!");
+      return result;
+    } catch (error) {
+      console.error('Erro ao selecionar a imagem:', error);
+      throw error;
     }
+  };
 
-    const uploadExam = async (patient, examInfo) => {
-        addInfo(patient, new ExamInfo(image, description));
-        simpleAlert();
-        getUserNavigate();
+  const simpleAlert = () => {
+    alert('Imagem e descrição enviados com sucesso!');
+  };
+
+  const getUserNavigate = async () => {
+    try {
+      let users = [];
+      let userRef = collection(db, 'usuario');
+      let acceptedQuery = query(userRef, where('email', '==', userGlobal.email));
+      let userSnapshot = await getDocs(acceptedQuery);
+      userSnapshot.forEach((u) => {
+        users.push({ dados: u.data() });
+      });
+
+      navigation.navigate('Examinador_Home', {
+        users: users,
+      });
+    } catch (error) {
+      console.error('Erro ao navegar para a tela de usuário:', error);
+      throw error;
     }
+  };
 
-    return (
-        <View style={styles.containerCentralize}>
-            <Text style={styles.title}>Dados da coleta</Text>
-            {/* <View style={styles.list_button_local}><Text style={styles.field_name_left}>{patient['dados']['nome_completo']}</Text></View> */}
-            <View style={styles.container}>
-            <Text style={styles.field_name}> Exame realizado em {patient['dados']['nome_completo']}</Text>
-            <Text style={styles.field_name}> Local: {patient['dados']['local']}</Text>
-            <Text style={styles.field_name}> Matrícula: {patient['dados']['matricula']}</Text>
-            <Text style={styles.field_name}> Solicitação: {patient['dados']['infos_solicitacao']}</Text>
-            </View>
-            <View style={styles.container_exame}>
-                <Pressable style={styles.list_button} onPress={ () => pickImage() }>
-                    <Text style={styles.field} > Clique aqui e selecione a imagem do exame na galeria </Text>
-                    <Icon name="upload" size={30} color='#4864b0' />
-                </Pressable></View>
-            {image&& <View style={styles.container_exame}>
-                <Icon_person style={styles.camera_icon} name="check" size={20} color='#A3E8A3'/>
-                <Text style={styles.subtitle}>Imagem Carregada</Text>
-            </View>}
-                <Text style={styles.field_name}>Descrição da imagem coletada </Text>
-                <TextInput 
-                    onChangeText={newDesc => setDescription(newDesc)}
-                    defaultValue={description}
-                    id="descricao"
-                    multiline={true}
-                    style={styles.big_field}
-                    placeholder="Informe o olho que a imagem foi capturada e demais informações relevantes" />
-            <View style={styles.container_exame}>
-            <Pressable onPress={ () => uploadExam(patient, new ExamInfo(image, description)) } style={styles.button_exam}>
-                <Text style={styles.text}>Enviar exame</Text>
-            </Pressable></View>
-            <StatusBar style="auto" />
+  return (
+    <View style={styles.containerCentralize}>
+      <Text style={styles.title}>Dados da coleta</Text>
+
+      <View style={styles.container}>
+        <Text style={styles.field_name}> Exame realizado em {patient['dados']['nome_completo']}</Text>
+        <Text style={styles.field_name}> Local: {patient['dados']['local']}</Text>
+        <Text style={styles.field_name}> Matrícula: {patient['dados']['matricula']}</Text>
+        <Text style={styles.field_name}> Solicitação: {patient['dados']['infos_solicitacao']}</Text>
+      </View>
+
+      <View style={styles.container_exame}>
+        <Pressable style={styles.list_button} onPress={() => pickImage('direito')}>
+          <Text style={styles.field}> Clique aqui e selecione a imagem do olho direito</Text>
+          <Icon name="upload" size={30} color="#4864b0" />
+        </Pressable>
+      </View>
+
+      {imageRight && (
+        <View style={styles.container_exame}>
+          <Icon_person style={styles.camera_icon} name="check" size={20} color="#A3E8A3" />
+          <Text style={styles.subtitle}>Imagem Carregada - Olho direito</Text>
         </View>
-    );
+      )}
+
+      <View style={styles.container_exame}>
+        <Pressable style={styles.list_button} onPress={() => pickImage('esquerdo')}>
+          <Text style={styles.field}> Clique aqui e selecione a imagem do olho esquerdo</Text>
+          <Icon name="upload" size={30} color="#4864b0" />
+        </Pressable>
+      </View>
+
+      {imageLeft && (
+        <View style={styles.container_exame}>
+          <Icon_person style={styles.camera_icon} name="check" size={20} color="#A3E8A3" />
+          <Text style={styles.subtitle}>Imagem Carregada - Olho esquerdo</Text>
+        </View>
+      )}
+
+      <Text style={styles.field_name}>Descrição da imagem</Text>
+      <TextInput
+        onChangeText={(newDesc) => setDescription(newDesc)}
+        defaultValue={description}
+        id="descricao"
+        multiline={true}
+        style={styles.big_field}
+        placeholder="Informe demais informações relevantes"
+      />
+
+      <View style={styles.container_exame}>
+        <Pressable onPress={() => uploadExam(patient, new ExamInfo([imageRight, imageLeft], description))} style={styles.button_exam}>
+          <Text style={styles.text}>Enviar exame</Text>
+        </Pressable>
+      </View>
+
+      <StatusBar style="auto" />
+    </View>
+  );
 }

--- a/views/Oftalmologista/Exames_Pendentes_Oftalmologista.js
+++ b/views/Oftalmologista/Exames_Pendentes_Oftalmologista.js
@@ -62,29 +62,49 @@ export default function Exames_Pendentes_Oftalmologista({ navigation }) {
             <View style={{ height: 50 }} />
             <Text style={styles.title}>Exames pendentes</Text>
             {!isLoaded && <p>Carregando...</p>}
-            <Text style={styles.patientText}> 
-            {isLoaded && exams.length == 0 && <p>Nenhum exame em andamento.</p>}
-            </Text>
-            {
-                isLoaded && exams.length > 0 && exams.map(patient => {
-                    return (
-                        <View style={styles.sub_container}>
-                            <Pressable style={styles.list_button} onPress={() => start_exam(patient)}>
-                                <View style={styles.list_information}>
-                                <View style={styles.list_button_local}>
-                                    <Icon style={styles.camera_icon} name="hospital" color='#363636' size={20}/>
-                                    <Text style={styles.subtitle}>{patient['dados']["local"]}</Text>
-                                </View>
-                                <View style={styles.list_button_local}>
-                                    <Icon_person style={styles.list_icon} name="person" size={20} color='#363636' />
-                                    <Text style={styles.patientText}>Paciente: {patient['dados']["nome_completo"]}</Text>
-                                </View>
-                                </View>
-                        </Pressable>
-                        </View>
-                )
-            })
-            }
+            {isLoaded && exams.length === 0 && (
+             <Text style={styles.patientText}>Nenhum exame em andamento.</Text>
+            )}
+    {
+        isLoaded &&
+        exams.length > 0 &&
+        exams.map((patient) => {
+            return (
+            <View style={styles.sub_container} key={patient.id}>
+                <Pressable style={styles.list_button} onPress={() => start_exam(patient)}>
+                <View style={styles.list_information}>
+                    <View style={styles.list_button_local}>
+                    <Icon
+                        style={styles.camera_icon}
+                        name="hospital"
+                        color="#363636"
+                        size={20}
+                    />
+                    <Text style={styles.subtitle}>{patient['dados']['local']}</Text>
+                    </View>
+                    <View style={styles.list_button_local}>
+                    <Icon_person
+                        style={styles.list_icon}
+                        name="person"
+                        size={20}
+                        color="#363636"
+                    />
+                    <Text style={styles.patientText}>
+                        Paciente: {patient['dados']['nome_completo']}
+                    </Text>
+                    </View>
+                </View>
+                </Pressable>
+                {patient['dados']['images'] && patient['dados']['images'].length > 0 && (
+                <Image
+                    source={{ uri: patient['dados']['images'][0] }}
+                    style={{ width: 100, height: 100 }}
+                />
+                )}
+            </View>
+            );
+        })
+    }
             <StatusBar style="auto" />
         </View>
     );

--- a/views/Oftalmologista/Laudo.js
+++ b/views/Oftalmologista/Laudo.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { Text, TextInput, View, Pressable, Image } from 'react-native';
+import { Text, View, Image, Pressable } from 'react-native';
 import { getDownloadURL, ref, getStorage } from 'firebase/storage';
 
 import styles from '../styles.js';
@@ -8,14 +8,16 @@ import { db } from '../../src/config/firebase.js';
 import { updateDoc, doc } from 'firebase/firestore';
 
 class ExamInfo {
-    constructor(diagnostico) {
-        this.diagnostico = diagnostico;
-    }
+  constructor(diagnostico, images) {
+    this.diagnostico = diagnostico;
+    this.images = images;
+  }
 }
 
 async function addExamInfo(patient, examInfo) {
+  try {
     let patientData = patient['dados'];
-    
+
     // cria referência do documento do paciente no banco de dados
     const patientRef = doc(db, 'exames', patient['id']);
 
@@ -23,112 +25,123 @@ async function addExamInfo(patient, examInfo) {
 
     // atualiza somente os campos diagnostico a partir de um JSON
     await updateDoc(patientRef, {
-        'diagnostico': examInfo.diagnostico,
-        'laudo_finalizado': true
+      'diagnostico': examInfo.diagnostico,
+      'laudo_finalizado': true,
     });
+
     return;
+  } catch (error) {
+    console.error('Erro ao adicionar informações do exame no laudo:', error);
+    throw error;
+  }
 }
 
 export default function Laudo({ route }) {
+  const { patient } = route.params;
+  const [urlRight, setUrlRight] = useState('');
+  const [urlLeft, setUrlLeft] = useState('');
+  const [data, setData] = useState('');
+  const [diagnostico, setDiagnostico] = useState('');
 
-    const { patient } = route.params;
-    const [ url, setUrl ] = useState('');
-    const [ data, setData ] = useState('');
-    const [diagnostico, setDiagnostico] = useState('');
-
-    const addInfo = async (patient, examInfo) => {
-        await addExamInfo(patient, examInfo);
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const storage = getStorage();
+  
+        // Verifica se 'images' está definido e possui pelo menos um elemento
+        if (patient['dados']['images'] && patient['dados']['images'].length > 0) {
+          const referenceRight = ref(storage, patient['dados']['images'][0]);
+          await getDownloadURL(referenceRight).then((x) => {
+            setUrlRight(x);
+          });
+        }
+  
+        // Verifica se 'images' está definido e possui mais de um elemento
+        if (patient['dados']['images'] && patient['dados']['images'].length > 1) {
+          const referenceLeft = ref(storage, patient['dados']['images'][1]);
+          await getDownloadURL(referenceLeft).then((x) => {
+            setUrlLeft(x);
+          });
+        }
+  
+        setData(formatDate(patient['dados']['data_de_nascimento'].toDate()));
+      } catch (error) {
+        console.error('Erro ao obter dados do paciente:', error);
+      }
     };
+  
+    fetchData();
+  }, []); 
 
-    const simpleAlert = () => {
-        alert("Laudo enviado com sucesso!");
-    }
+  const formatDate = (dateString) => {
+    const options = { year: 'numeric', month: 'long', day: 'numeric' };
+    return new Date(dateString).toLocaleDateString(undefined, options);
+  };
 
-    const uploadLaudo = async (patient, examInfo) => {
-        addInfo(patient, new ExamInfo(diagnostico));
-        simpleAlert();
-    }
+  const [showFullScreenRight, setShowFullScreenRight] = useState(false);
+  const [showFullScreenLeft, setShowFullScreenLeft] = useState(false);
 
-    useEffect(() => {
-        const func = async () => {
-            const storage = getStorage();
-            const reference = ref(storage, patient['dados']['image']);
+  const handleImageClick = (eye) => {
+    eye === 'direito' ? setShowFullScreenRight(true) : setShowFullScreenLeft(true);
+  };
 
-            setData(formatDate(patient['dados']['data_de_nascimento'].toDate()));
-            
-            await getDownloadURL(reference).then((x => {
-                setUrl(x);
-            })
-            );};
-            func();
-    }, []);
+  const handleCloseFullScreen = (eye) => {
+    eye === 'direito' ? setShowFullScreenRight(false) : setShowFullScreenLeft(false);
+  };
 
-    const formatDate = (dateString) => {// Alterar, está dando data invalida
-        const options = { year: "numeric", month: "long", day: "numeric"}
-        return new Date(dateString).toLocaleDateString(undefined, options)
-    }
+  return (
+    <View style={styles.container}>
+      <View style={{ height: 50 }} />
+      <Text style={styles.title}>Paciente</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['nome_completo']}</Text>
+      <Text style={styles.title}>Sexo</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['sexo']}</Text>
+      <Text style={styles.title}>Data de nascimento</Text>
+      <Text style={styles.field_name_left_small}>{data}</Text>
+      <Text style={styles.title}>Raça</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['raca']}</Text>
+      <Text style={styles.title}>Local</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['local']}</Text>
+      <Text style={styles.title}>Matrícula</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['matricula']}</Text>
+      <Text style={styles.title}>Leito atual</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['leito_atual']}</Text>
+      <Text style={styles.title}>Histórico</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['historico_paciente']}</Text>
+      <Text style={styles.title}>Informações da solicitação</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['infos_solicitacao']}</Text>
 
-    const [showFullScreen, setShowFullScreen] = useState(false);
+      <Text style={styles.title}>Examinador</Text>
+      <Text style={styles.field_name_left_small}>{patient['dados']['examinador']}</Text>
+      <Text style={styles.title}>Exame</Text>
+      <Text style={styles.field_name_img}>
+        Visualizar Imagem Olho Direito
+        <View style={{ width: 20 }} />
+        <Image onClick={() => handleImageClick('direito')} source={{ uri: urlRight }} style={{ height: 80, width: 120 }} />
 
-    const handleImageClick = () => {
-        setShowFullScreen(true);
-    };
+        {showFullScreenRight && (
+          <Image onClick={() => handleCloseFullScreen('direito')} source={{ uri: urlRight }} style={styles.img_full} />
+        )}
+      </Text>
 
-    const handleCloseFullScreen = () => {
-        setShowFullScreen(false);
-    };
-    
+      {urlLeft && (
+        <Text style={styles.field_name_img}>
+          Visualizar Imagem Olho Esquerdo
+          <View style={{ width: 20 }} />
+          <Image onClick={() => handleImageClick('esquerdo')} source={{ uri: urlLeft }} style={{ height: 80, width: 120 }} />
 
-    return (
-        <View style={styles.container}>
-            <View style={{ height: 50 }} />
-            <Text style={styles.title}>Paciente</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['nome_completo']}</Text>
-            <Text style={styles.title}>Sexo</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['sexo']}</Text>
-            <Text style={styles.title}>Data de nascimento</Text>
-            <Text style={styles.field_name_left_small}>{data}</Text>
-            <Text style={styles.title}>Raça</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['raca']}</Text>
-            <Text style={styles.title}>Local</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['local']}</Text>
-            <Text style={styles.title}>Matrícula</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['matricula']}</Text>
-            <Text style={styles.title}>Leito atual</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['leito_atual']}</Text>
-            <Text style={styles.title}>Histórico</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['historico_paciente']}</Text>
-            <Text style={styles.title}>Informações da solicitação</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['infos_solicitacao']}</Text>
+          {showFullScreenLeft && (
+            <Image onClick={() => handleCloseFullScreen('esquerdo')} source={{ uri: urlLeft }} style={styles.img_full} />
+          )}
+        </Text>
 
-            <Text style={styles.title}>Examinador</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['examinador']}</Text>
-            <Text style={styles.title}>Exame</Text>
-            <Text style={styles.field_name_img}>
-                Visualizar Imagem
-                <View style={{ width: 20 }} />
-                <Image onClick={handleImageClick} source={{ uri: url }} style={{ height: 80, width:120}} />
-
-                {showFullScreen && (
-                    <Image onClick={handleCloseFullScreen} source={{ uri: url }} style={styles.img_full} />
-                )}
-            </Text>
-            <Text style={styles.title}>Descrição</Text>
-            <Text style={styles.field_name_left_small}>{patient['dados']['description']}</Text>
-
-            <Text style={styles.title}>Diagnóstico</Text>
-            <TextInput 
-                onChangeText={newDesc => setDiagnostico(newDesc)}
-                defaultValue={diagnostico}
-                id="diagnostico"
-                multiline={true}
-                style={styles.big_field}
-                placeholder="Descreva o diagnóstico" />
-            <Pressable onPress={ () => uploadLaudo(patient, new ExamInfo(diagnostico)) } style={styles.button}>
-                <Text style={styles.text}>Enviar laudo</Text>
-            </Pressable>
-            <View style={{ height: 25 }} />
-            <StatusBar style="auto" />
+        <View>
+            <Text style={styles.title}>Imagem Olho Esquerdo</Text>
+            {urlLeft && <Image source={{ uri: urlLeft }} style={{ height: 200, width: 300 }} />}
         </View>
-    );
+      )}
+
+      <StatusBar style="auto" />
+    </View>
+  );
 }

--- a/views/styles.js
+++ b/views/styles.js
@@ -463,6 +463,13 @@ const styles = StyleSheet.create({
       width: 100,
       fontWeight: 'bold'
     },
+    eyeImage: {
+      height: 80,
+      width: 120,
+    },
+    img_full: {
+      // tela cheia
+    },
     viewImageLogo: {
       display: 'flex',
       alignItems: 'center',


### PR DESCRIPTION
Aqui já insere duas imagens no Examinador e armazena no banco
Tentando inserir as imagens no perfil do oftalmo, ainda não com exito. Se alguém quiser pegar para ir testando e experimentando, sinta-se livre
Requisitos do item no trello:

Done. Laudos possuem a visualização das imagens do exame de olho e devem ser alterados para o template aceitar duas imagens
Done. Código alterado para receber as duas entradas. No banco, o registro de um exame possui a entrada de cada uma das imagens separadamente e elas recebem um id + “ olho direito / esquerdo” para identificar.
In progress. A visualização das imagens ainda está in progress. O primeiro perfil que está tentando receber a visualização é o perfil de oftalmologista.
Done. imagens salvas com sucesso (podendo fazer o download corretamente).